### PR TITLE
Fix command name

### DIFF
--- a/internal/cmd/delete/workload.go
+++ b/internal/cmd/delete/workload.go
@@ -24,7 +24,7 @@ import (
 
 // workloadCmd represents the workload command
 var workloadCmd = &cobra.Command{
-	Use:   "Delete workload",
+	Use:   "workload",
 	Short: "Delete the workload from flotta",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
The command name for workload's action should be simply: workload.

Signed-off-by: Moti Asayag <masayag@redhat.com>