### PR TITLE
Change args to flags for usability

### DIFF
--- a/internal/cmd/add/device.go
+++ b/internal/cmd/add/device.go
@@ -22,11 +22,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var deviceName string
+
 // deviceCmd represents the device command
 var deviceCmd = &cobra.Command{
 	Use:   "device",
 	Short: "Add a new device",
-	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		client, err := resources.NewClient()
 		if err != nil {
@@ -34,7 +35,7 @@ var deviceCmd = &cobra.Command{
 			return
 		}
 
-		device, err := resources.NewEdgeDevice(client, args[0])
+		device, err := resources.NewEdgeDevice(client, deviceName)
 		if err != nil {
 			fmt.Printf("NewEdgeDevice failed: %v\n", err)
 			return
@@ -60,4 +61,8 @@ var deviceCmd = &cobra.Command{
 func init() {
 	// subcommand of add
 	addCmd.AddCommand(deviceCmd)
+
+	// define command flags
+	deviceCmd.Flags().StringVarP(&deviceName, "name", "n", "", "name of the device to add")
+	deviceCmd.MarkFlagRequired("name")
 }

--- a/internal/cmd/add/workload.go
+++ b/internal/cmd/add/workload.go
@@ -40,7 +40,6 @@ var (
 	workloadCmd = &cobra.Command{
 		Use:   "workload",
 		Short: "Add a new workload",
-		Args:  cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			if workloadImage == "" {
 				workloadImage = defaultImage
@@ -54,10 +53,8 @@ var (
 				return
 			}
 
-			if len(args) == 0 {
+			if len(workloadName) == 0 {
 				workloadName = normalizedImage + "-" + RandomSuffix()
-			} else {
-				workloadName = args[0]
 			}
 
 			client, err := resources.NewClient()
@@ -72,6 +69,10 @@ var (
 				return
 			}
 
+			_, err = device.Get(); if err != nil {
+				fmt.Printf("Get device %s failed: %v\n", deviceID, err)
+				return
+			}
 			workload, err := resources.NewEdgeWorkload(client)
 			if err != nil {
 				fmt.Printf("NewEdgeWorkload failed: %v\n", err)
@@ -100,15 +101,12 @@ func init() {
 	addCmd.AddCommand(workloadCmd)
 
 	// define command flags
-	workloadCmd.PersistentFlags().StringVarP(&deviceID, "device", "d", "", "device to run the container workload on")
-	workloadCmd.PersistentFlags().StringVarP(&workloadImage, "image", "i", "", "image of the workload")
+	workloadCmd.Flags().StringVarP(&deviceID, "device", "d", "", "device to run the workload on")
+	workloadCmd.Flags().StringVarP(&workloadName, "name", "n", "", "name of the workload to add")
+	workloadCmd.Flags().StringVarP(&workloadImage, "image", "i", "", "image of the workload")
 
 	// mark device flag as required
-	err := workloadCmd.MarkPersistentFlagRequired("device")
-	if err != nil {
-		fmt.Printf("MarkPersistentFlagRequired for workload failed: %v\n", err)
-		return
-	}
+	workloadCmd.MarkFlagRequired("device")
 }
 
 func RandomSuffix() string {

--- a/internal/cmd/delete/device.go
+++ b/internal/cmd/delete/device.go
@@ -24,11 +24,12 @@ import (
 	"github.com/project-flotta/flotta-dev-cli/internal/resources"
 )
 
+var deviceName string
+
 // deviceCmd represents the device command
 var deviceCmd = &cobra.Command{
 	Use:   "device",
 	Short: "Delete the device from flotta",
-	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		client, err := resources.NewClient()
 		if err != nil {
@@ -36,7 +37,7 @@ var deviceCmd = &cobra.Command{
 			return
 		}
 
-		device, err := resources.NewEdgeDevice(client, args[0])
+		device, err := resources.NewEdgeDevice(client, deviceName)
 		if err != nil {
 			fmt.Printf("NewEdgeDevice failed: %v\n", err)
 			return
@@ -61,4 +62,8 @@ var deviceCmd = &cobra.Command{
 func init() {
 	// subcommand of delete
 	deleteCmd.AddCommand(deviceCmd)
+
+	// define command flags
+	deviceCmd.Flags().StringVarP(&deviceName, "name", "n", "", "name of the device to delete")
+	deviceCmd.MarkFlagRequired("name")
 }

--- a/internal/cmd/delete/workload.go
+++ b/internal/cmd/delete/workload.go
@@ -22,11 +22,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var workloadName string
+
 // workloadCmd represents the workload command
 var workloadCmd = &cobra.Command{
 	Use:   "workload",
 	Short: "Delete the workload from flotta",
-	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		client, err := resources.NewClient()
 		if err != nil {
@@ -40,17 +41,21 @@ var workloadCmd = &cobra.Command{
 			return
 		}
 
-		err = workload.Remove(args[0])
+		err = workload.Remove(workloadName)
 		if err != nil {
 			fmt.Printf("Remove workload failed: %v\n", err)
 			return
 		}
 
-		fmt.Printf("workload '%v' was deleted \n", args[0])
+		fmt.Printf("workload '%v' was deleted \n", workloadName)
 	},
 }
 
 func init() {
 	// subcommand of delete
 	deleteCmd.AddCommand(workloadCmd)
+
+	// define command flags
+	workloadCmd.Flags().StringVarP(&workloadName, "name", "n", "", "name of the workload to delete")
+	workloadCmd.MarkFlagRequired("name")
 }

--- a/internal/cmd/start/device.go
+++ b/internal/cmd/start/device.go
@@ -23,11 +23,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var deviceName string
+
 // deviceCmd represents the device command
 var deviceCmd = &cobra.Command{
 	Use:   "device",
 	Short: "Start the device",
-	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		client, err := resources.NewClient()
 		if err != nil {
@@ -35,7 +36,7 @@ var deviceCmd = &cobra.Command{
 			return
 		}
 
-		device, err := resources.NewEdgeDevice(client, args[0])
+		device, err := resources.NewEdgeDevice(client, deviceName)
 		if err != nil {
 			fmt.Printf("NewEdgeDevice failed: %v\n", err)
 			return
@@ -54,4 +55,8 @@ var deviceCmd = &cobra.Command{
 func init() {
 	// subcommand of start
 	startCmd.AddCommand(deviceCmd)
+
+	// define command flags
+	deviceCmd.Flags().StringVarP(&deviceName, "name", "n", "", "name of the device to start")
+	deviceCmd.MarkFlagRequired("name")
 }

--- a/internal/cmd/stop/device.go
+++ b/internal/cmd/stop/device.go
@@ -22,11 +22,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var deviceName string
+
 // deviceCmd represents the device command
 var deviceCmd = &cobra.Command{
 	Use:   "device",
 	Short: "Stop the device",
-	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		client, err := resources.NewClient()
 		if err != nil {
@@ -34,7 +35,7 @@ var deviceCmd = &cobra.Command{
 			return
 		}
 
-		device, err := resources.NewEdgeDevice(client, args[0])
+		device, err := resources.NewEdgeDevice(client, deviceName)
 		if err != nil {
 			fmt.Printf("NewEdgeDevice failed: %v\n", err)
 			return
@@ -53,4 +54,8 @@ var deviceCmd = &cobra.Command{
 func init() {
 	// subcommand of stop
 	stopCmd.AddCommand(deviceCmd)
+
+	// define command flags
+	deviceCmd.Flags().StringVarP(&deviceName, "name", "n", "", "name of the device to stop")
+	deviceCmd.MarkFlagRequired("name")
 }


### PR DESCRIPTION
This PR introduces several changes with respect to using the cli:
* Persistent flags in sub-commands were changed to Flags to avoid
  unnecessary delegation to sub-commands.
* Args were replaced with Flags to provide expected parameters to
  sub-commands by their names.
* Add workload changed to fail if the device is missing.

Signed-off-by: Moti Asayag <masayag@redhat.com>