### PR TITLE
Improve error message `Register failed: error waiting for edgedevice`

### DIFF
--- a/internal/resources/edgedevice.go
+++ b/internal/resources/edgedevice.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
 	"strings"
@@ -235,7 +236,12 @@ func (e *edgeDevice) waitForDevice(cond func() bool) error {
 		}
 	}
 
-	return fmt.Errorf("error waiting for edgedevice %v[%v]", e.name, e.name)
+	res, err := exec.Command("minikube", "status", "--format", "{{.Host}}").Output()
+	portForward := ""
+	if err == nil && string(res) == "Running" {
+		portForward = ". `minikube` cluster is running, is `kubectl port-forward` command executing?"
+	}
+	return fmt.Errorf("error waiting for edgedevice %v[%v]%s", e.name, e.name, portForward)
 }
 
 func (e *edgeDevice) WaitForWorkloadState(workloadName string, workloadPhase v1alpha1.EdgeWorkloadPhase) error {


### PR DESCRIPTION
When using `minikube` it is necessary to run `kubect port-forward` command.
After a reboot, it's possible that the developer may forget to run the `kubectl port-forward` command.

This PR checks if there is a `minikube` cluster running and enriches the error message.

Signed-off-by: Gloria Ciavarrini <gciavarrini@redhat.com>