### PR TITLE
Add option to use plural form of sub-command

### DIFF
--- a/internal/cmd/list/device.go
+++ b/internal/cmd/list/device.go
@@ -32,8 +32,9 @@ import (
 
 // deviceCmd represents the device command
 var deviceCmd = &cobra.Command{
-	Use:   "device",
-	Short: "List devices",
+	Use:     "device",
+	Aliases: []string{"devices"},
+	Short:   "List devices",
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.Background()
 		cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())

--- a/internal/cmd/list/workload.go
+++ b/internal/cmd/list/workload.go
@@ -35,8 +35,9 @@ import (
 
 // workloadCmd represents the workload command
 var workloadCmd = &cobra.Command{
-	Use:   "workload",
-	Short: "List workloads",
+	Use:     "workload",
+	Aliases: []string{"workloads"},
+	Short:   "List workloads",
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.Background()
 		cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())


### PR DESCRIPTION
Now `list devices` \ `list workloads` are available as well.

This PR solves #44.

Signed-off-by: arielireni <aireni@redhat.com>