### PR TITLE
Add aliases to use plural form of sub-commands

### DIFF
--- a/internal/cmd/add/device.go
+++ b/internal/cmd/add/device.go
@@ -29,6 +29,7 @@ var deviceName string
 // deviceCmd represents the device command
 var deviceCmd = &cobra.Command{
 	Use:   "device",
+	Aliases: []string{"devices"},
 	Short: "Add a new device",
 	Run: func(cmd *cobra.Command, args []string) {
 		client, err := resources.NewClient()

--- a/internal/cmd/add/workload.go
+++ b/internal/cmd/add/workload.go
@@ -41,6 +41,7 @@ var (
 
 	workloadCmd = &cobra.Command{
 		Use:   "workload",
+		Aliases: []string{"workloads"},
 		Short: "Add a new workload",
 		Run: func(cmd *cobra.Command, args []string) {
 			if workloadImage == "" {

--- a/internal/cmd/delete/device.go
+++ b/internal/cmd/delete/device.go
@@ -30,6 +30,7 @@ var deviceName string
 // deviceCmd represents the device command
 var deviceCmd = &cobra.Command{
 	Use:   "device",
+	Aliases: []string{"devices"},
 	Short: "Delete a device from flotta",
 	Run: func(cmd *cobra.Command, args []string) {
 		client, err := resources.NewClient()

--- a/internal/cmd/delete/workload.go
+++ b/internal/cmd/delete/workload.go
@@ -29,6 +29,7 @@ var workloadName string
 // workloadCmd represents the workload command
 var workloadCmd = &cobra.Command{
 	Use:   "workload",
+	Aliases: []string{"workloads"},
 	Short: "Delete a workload from flotta",
 	Run: func(cmd *cobra.Command, args []string) {
 		client, err := resources.NewClient()

--- a/internal/cmd/start/device.go
+++ b/internal/cmd/start/device.go
@@ -29,6 +29,7 @@ var deviceName string
 // deviceCmd represents the device command
 var deviceCmd = &cobra.Command{
 	Use:   "device",
+	Aliases: []string{"devices"},
 	Short: "Start a device",
 	Run: func(cmd *cobra.Command, args []string) {
 		client, err := resources.NewClient()

--- a/internal/cmd/stop/device.go
+++ b/internal/cmd/stop/device.go
@@ -29,6 +29,7 @@ var deviceName string
 // deviceCmd represents the device command
 var deviceCmd = &cobra.Command{
 	Use:   "device",
+	Aliases: []string{"devices"},
 	Short: "Stop a device",
 	Run: func(cmd *cobra.Command, args []string) {
 		client, err := resources.NewClient()


### PR DESCRIPTION
Added aliases to the sub-commands of `add`, `delete`, `start`, and `stop`.

Signed-off-by: arielireni <aireni@redhat.com>