### PR TITLE
Add `add deviceset` command

### DIFF
--- a/internal/cmd/add/deviceset.go
+++ b/internal/cmd/add/deviceset.go
@@ -1,0 +1,127 @@
+package add
+
+import (
+	"context"
+	"fmt"
+	"github.com/project-flotta/flotta-dev-cli/internal/resources"
+	"github.com/spf13/cobra"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"os"
+)
+
+// deviceSetCmd represents the device set command
+var (
+	deviceSetName    string
+	deviceSetSize    int
+	deviceNamePrefix string
+
+	deviceSetCmd = &cobra.Command{
+		Use:     "deviceset",
+		Aliases: []string{"devicesets"},
+		Short:   "Add a new device set with registered devices",
+		Run: func(cmd *cobra.Command, args []string) {
+			if deviceSetSize < 0 {
+				fmt.Printf("deviceSetSize is invalid: %d. Only positive values are allowed\n", deviceSetSize)
+				return
+			}
+
+			// if devices prefix has not been specified, use deviceSetName as prefix
+			if deviceNamePrefix == "" {
+				deviceNamePrefix = deviceSetName
+			}
+
+			client, err := resources.NewClient()
+			if err != nil {
+				fmt.Printf("NewClient failed: %v\n", err)
+				return
+			}
+
+			deviceset, err := resources.NewEdgeDeviceSet(client, deviceSetName)
+			if err != nil {
+				fmt.Printf("NewEdgeDeviceSet failed: %v\n", err)
+				return
+			}
+
+			_, err = deviceset.Create(resources.EdgeDeviceSetConfig(deviceSetName))
+			if err != nil {
+				fmt.Printf("Create deviceset failed: %v\n", err)
+				return
+			}
+
+			fmt.Printf("deviceset '%s' was added\n", deviceSetName)
+
+			// add devices to the deviceset
+			devicesCreated := 0
+			for i := 1; i <= deviceSetSize; i++ {
+				deviceName := fmt.Sprintf("%s%d", deviceNamePrefix, i)
+				err := NewDeviceToSet(deviceSetName, deviceName)
+				if err != nil {
+					fmt.Printf("NewDeviceToSet failed: %v. Device: %s\n", err, deviceName)
+				} else {
+					devicesCreated += 1
+					fmt.Printf("device '%s' was added successfully to device-set '%s' (%d/%d)\n", deviceName, deviceSetName, devicesCreated, deviceSetSize)
+				}
+			}
+		},
+	}
+)
+
+func init() {
+	// subcommand of add
+	addCmd.AddCommand(deviceSetCmd)
+
+	// define command flags
+	deviceSetCmd.Flags().StringVarP(&deviceSetName, "name", "n", "", "name of the deviceset to add")
+	deviceSetCmd.Flags().IntVarP(&deviceSetSize, "size", "s", 0, "the amount of edge devices to be created and added to the device set")
+	deviceSetCmd.Flags().StringVarP(&deviceNamePrefix, "prefix", "p", "", "the name prefix of the devices to add to the deviceset")
+
+	// mark name flag as required
+	err := deviceSetCmd.MarkFlagRequired("name")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to set flag `name` as required: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func NewDeviceToSet(deviceSetName, deviceName string) error {
+	client, err := resources.NewClient()
+	if err != nil {
+		fmt.Printf("NewClient failed: %v\n", err)
+		return err
+	}
+
+	device, err := resources.NewEdgeDevice(client, deviceName)
+	if err != nil {
+		fmt.Printf("NewEdgeDevice failed: %v\n", err)
+		return err
+	}
+
+	err = device.Register()
+	if err != nil {
+		// if device.Register() failed, remove the container
+		err2 := device.Remove()
+		if err2 != nil {
+			fmt.Printf("Remove device that failed to register failed: %v\n", err2)
+			return err2
+		}
+
+		fmt.Printf("Register failed: %v\n", err)
+		return err
+	}
+
+	// get the new device in order to add 'flotta/member-of' label
+	dvc, err := device.Get()
+	if err != nil {
+		fmt.Printf("Get device %s failed: %v\n", deviceName, err)
+		return err
+	}
+
+	// update the device
+	dvc.Labels["flotta/member-of"] = deviceSetName
+	dvc, err = client.EdgeDevices("default").Update(context.TODO(), dvc, v1.UpdateOptions{})
+	if err != nil {
+		fmt.Printf("Update device '%s' failed: %v\n", dvc.Name, err)
+	}
+
+	return nil
+}

--- a/internal/resources/edgedeviceset.go
+++ b/internal/resources/edgedeviceset.go
@@ -1,0 +1,89 @@
+package resources
+
+import (
+	"context"
+	"fmt"
+	"github.com/project-flotta/flotta-operator/api/v1alpha1"
+	mgmtv1alpha1 "github.com/project-flotta/flotta-operator/generated/clientset/versioned/typed/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"time"
+)
+
+type EdgeDeviceSet interface {
+	GetName() string
+	Create(set *v1alpha1.EdgeDeviceSet) (*v1alpha1.EdgeDeviceSet, error)
+	Get(string) (*v1alpha1.EdgeDeviceSet, error)
+	Remove(string) error
+	RemoveAll() error
+}
+
+type edgeDeviceSet struct {
+	deviceset mgmtv1alpha1.ManagementV1alpha1Interface
+	name      string
+}
+
+func NewEdgeDeviceSet(client mgmtv1alpha1.ManagementV1alpha1Interface, deviceSetName string) (*edgeDeviceSet, error) {
+	return &edgeDeviceSet{deviceset: client, name: deviceSetName}, nil
+}
+
+func (e *edgeDeviceSet) GetName() string {
+	return e.name
+}
+
+func (e *edgeDeviceSet) Get(name string) (*v1alpha1.EdgeDeviceSet, error) {
+	return e.deviceset.EdgeDeviceSets(Namespace).Get(context.TODO(), name, metav1.GetOptions{})
+}
+
+func (e *edgeDeviceSet) Create(eds *v1alpha1.EdgeDeviceSet) (*v1alpha1.EdgeDeviceSet, error) {
+	return e.deviceset.EdgeDeviceSets(Namespace).Create(context.TODO(), eds, metav1.CreateOptions{})
+}
+
+func (e *edgeDeviceSet) RemoveAll() error {
+	return e.deviceset.EdgeDeviceSets(Namespace).DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{})
+}
+
+func (e *edgeDeviceSet) Remove(name string) error {
+	err := e.deviceset.EdgeDeviceSets(Namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
+	if err != nil {
+		return err
+	}
+
+	return e.waitForDeviceSet(func() bool {
+		if _, err := e.Get(name); err != nil {
+			return true
+		}
+		return false
+	})
+}
+
+func (e *edgeDeviceSet) waitForDeviceSet(cond func() bool) error {
+	for i := 0; i <= waitTimeout; i += sleepInterval {
+		if cond() {
+			return nil
+		} else {
+			time.Sleep(time.Duration(sleepInterval) * time.Second)
+		}
+	}
+
+	return fmt.Errorf("error waiting for edge device set")
+}
+
+func EdgeDeviceSetConfig(name string) *v1alpha1.EdgeDeviceSet {
+	deviceset := &v1alpha1.EdgeDeviceSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: v1alpha1.EdgeDeviceSetSpec{
+			Heartbeat: &v1alpha1.HeartbeatConfiguration{
+				PeriodSeconds: 5,
+			},
+			Metrics: &v1alpha1.MetricsConfiguration{
+				SystemMetrics: &v1alpha1.SystemMetricsConfiguration{
+					Interval: 600,
+				},
+			},
+		},
+	}
+
+	return deviceset
+}


### PR DESCRIPTION
Added deviceset implementation to the resources package.
Added `add deviceset -n <deviceset-name> -s <size-of-deviceset> -p <device-name-prefix>` command, where only the name flag is mandatory.

Signed-off-by: arielireni <aireni@redhat.com>