### PR TITLE
Replace the use of `io/ioutil` package with `io` and `os`

### DIFF
--- a/internal/cmd/add/device.go
+++ b/internal/cmd/add/device.go
@@ -28,9 +28,9 @@ var deviceName string
 
 // deviceCmd represents the device command
 var deviceCmd = &cobra.Command{
-	Use:   "device",
+	Use:     "device",
 	Aliases: []string{"devices"},
-	Short: "Add a new device",
+	Short:   "Add a new device",
 	Run: func(cmd *cobra.Command, args []string) {
 		client, err := resources.NewClient()
 		if err != nil {

--- a/internal/cmd/add/workload.go
+++ b/internal/cmd/add/workload.go
@@ -40,9 +40,9 @@ var (
 	workloadName  string
 
 	workloadCmd = &cobra.Command{
-		Use:   "workload",
+		Use:     "workload",
 		Aliases: []string{"workloads"},
-		Short: "Add a new workload",
+		Short:   "Add a new workload",
 		Run: func(cmd *cobra.Command, args []string) {
 			if workloadImage == "" {
 				workloadImage = defaultImage

--- a/internal/cmd/delete/device.go
+++ b/internal/cmd/delete/device.go
@@ -29,9 +29,9 @@ var deviceName string
 
 // deviceCmd represents the device command
 var deviceCmd = &cobra.Command{
-	Use:   "device",
+	Use:     "device",
 	Aliases: []string{"devices"},
-	Short: "Delete a device from flotta",
+	Short:   "Delete a device from flotta",
 	Run: func(cmd *cobra.Command, args []string) {
 		client, err := resources.NewClient()
 		if err != nil {

--- a/internal/cmd/delete/workload.go
+++ b/internal/cmd/delete/workload.go
@@ -28,9 +28,9 @@ var workloadName string
 
 // workloadCmd represents the workload command
 var workloadCmd = &cobra.Command{
-	Use:   "workload",
+	Use:     "workload",
 	Aliases: []string{"workloads"},
-	Short: "Delete a workload from flotta",
+	Short:   "Delete a workload from flotta",
 	Run: func(cmd *cobra.Command, args []string) {
 		client, err := resources.NewClient()
 		if err != nil {

--- a/internal/cmd/start/device.go
+++ b/internal/cmd/start/device.go
@@ -28,9 +28,9 @@ var deviceName string
 
 // deviceCmd represents the device command
 var deviceCmd = &cobra.Command{
-	Use:   "device",
+	Use:     "device",
 	Aliases: []string{"devices"},
-	Short: "Start a device",
+	Short:   "Start a device",
 	Run: func(cmd *cobra.Command, args []string) {
 		client, err := resources.NewClient()
 		if err != nil {

--- a/internal/cmd/stop/device.go
+++ b/internal/cmd/stop/device.go
@@ -28,9 +28,9 @@ var deviceName string
 
 // deviceCmd represents the device command
 var deviceCmd = &cobra.Command{
-	Use:   "device",
+	Use:     "device",
 	Aliases: []string{"devices"},
-	Short: "Stop a device",
+	Short:   "Stop a device",
 	Run: func(cmd *cobra.Command, args []string) {
 		client, err := resources.NewClient()
 		if err != nil {

--- a/internal/resources/edgedevice.go
+++ b/internal/resources/edgedevice.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -84,7 +84,7 @@ func (e *edgeDevice) Register(cmds ...string) error {
 		return fmt.Errorf("failed to pull image '%s': %v", image, err)
 	}
 	defer out.Close()
-	if _, err := ioutil.ReadAll(out); err != nil {
+	if _, err := io.ReadAll(out); err != nil {
 		return err
 	}
 
@@ -216,7 +216,7 @@ func (e *edgeDevice) Exec(command string) (string, error) {
 	}
 	defer response.Close()
 
-	data, err := ioutil.ReadAll(response.Reader)
+	data, err := io.ReadAll(response.Reader)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
golangci-lint failed in PR #61 due to a deprecated use of package `io/ioutil` in `resources/edgedevice.go` file.

Also, this PR includes changes from re-building the project in the device/workload commands files.

Signed-off-by: arielireni <aireni@redhat.com>