### PR TITLE
Add `list deviceset` command

### DIFF
--- a/internal/cmd/list/deviceset.go
+++ b/internal/cmd/list/deviceset.go
@@ -1,0 +1,88 @@
+package list
+
+/*
+Copyright © 2022 NAME HERE <EMAIL ADDRESS>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import (
+	"fmt"
+	"github.com/docker/go-units"
+	"github.com/spf13/cobra"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/project-flotta/flotta-dev-cli/internal/resources"
+)
+
+// deviceSetCmd represents the deviceSet command
+var deviceSetCmd = &cobra.Command{
+	Use:     "deviceset",
+	Aliases: []string{"devicesets"},
+	Short:   "List device-sets",
+	Run: func(cmd *cobra.Command, args []string) {
+
+		writer := tabwriter.NewWriter(os.Stdout, 0, 8, 2, '\t', tabwriter.AlignRight)
+		defer writer.Flush()
+		fmt.Fprintf(writer, "%s\t%s\t%s\t\n", "NAME", "DEVICES", "CREATED")
+
+		client, err := resources.NewClient()
+		if err != nil {
+			fmt.Printf("NewClient failed: %v\n", err)
+			return
+		}
+
+		// create a list of all device-sets
+		deviceset, err := resources.NewEdgeDeviceSet(client, "")
+		if err != nil {
+			fmt.Printf("NewEdgeDeviceSet failed: %v\n", err)
+		}
+		setsList, err := deviceset.List()
+		if err != nil {
+			fmt.Printf("List() device-set failed: %v\n", err)
+		}
+
+		// create a list of all registered devices
+		device, err := resources.NewEdgeDevice(client, "")
+		if err != nil {
+			fmt.Printf("NewEdgeDeviceSet failed: %v\n", err)
+		}
+		devicesList, err := device.List()
+		if err != nil {
+			fmt.Printf("List() device failed: %v\n", err)
+		}
+
+		// create a map of sets names and their devices
+		devicesMap := make(map[string][]string)
+		for _, dvc := range devicesList.Items {
+			if labelValue, ok := dvc.Labels["flotta/member-of"]; ok {
+				devicesMap[labelValue] = append(devicesMap[labelValue], dvc.Name)
+			}
+		}
+
+		// output all device-sets and their devices
+		for _, set := range setsList.Items {
+			devices := strings.Join(devicesMap[set.Name], ", ")
+			runningFor := units.HumanDuration(time.Now().UTC().Sub(set.CreationTimestamp.Time)) + " ago"
+			fmt.Fprintf(writer, "%s\t%v\t%s\t\n", set.Name, devices, runningFor)
+		}
+	},
+}
+
+func init() {
+	// subcommand of list
+	listCmd.AddCommand(deviceSetCmd)
+}

--- a/internal/resources/edgedevice.go
+++ b/internal/resources/edgedevice.go
@@ -48,6 +48,7 @@ type EdgeDevice interface {
 	Register(cmds ...string) error
 	Unregister() error
 	Get() (*v1alpha1.EdgeDevice, error)
+	List() (*v1alpha1.EdgeDeviceList, error)
 	Remove() error
 	Stop() error
 	Start() error
@@ -160,6 +161,10 @@ func (e *edgeDevice) Get() (*v1alpha1.EdgeDevice, error) {
 	}
 
 	return device, nil
+}
+
+func (e *edgeDevice) List() (*v1alpha1.EdgeDeviceList, error) {
+	return e.device.EdgeDevices(Namespace).List(context.TODO(), metav1.ListOptions{})
 }
 
 func (e *edgeDevice) Stop() error {

--- a/internal/resources/edgedeviceset.go
+++ b/internal/resources/edgedeviceset.go
@@ -15,6 +15,7 @@ type EdgeDeviceSet interface {
 	Get(string) (*v1alpha1.EdgeDeviceSet, error)
 	Remove(string) error
 	RemoveAll() error
+	List() (*v1alpha1.EdgeDeviceSetList, error)
 }
 
 type edgeDeviceSet struct {
@@ -32,6 +33,10 @@ func (e *edgeDeviceSet) GetName() string {
 
 func (e *edgeDeviceSet) Get(name string) (*v1alpha1.EdgeDeviceSet, error) {
 	return e.deviceset.EdgeDeviceSets(Namespace).Get(context.TODO(), name, metav1.GetOptions{})
+}
+
+func (e *edgeDeviceSet) List() (*v1alpha1.EdgeDeviceSetList, error) {
+	return e.deviceset.EdgeDeviceSets(Namespace).List(context.TODO(), metav1.ListOptions{})
 }
 
 func (e *edgeDeviceSet) Create(eds *v1alpha1.EdgeDeviceSet) (*v1alpha1.EdgeDeviceSet, error) {


### PR DESCRIPTION
The output of the command will be a list of all device-sets and their devices. For example:
```
→ ./bin/flotta list deviceset
NAME	DEVICES			CREATED
set1	device1, device2	16 hours ago
set2	set21, set22		About an hour ago
```

Also, this PR includes implementation of `List()` function for `EdgeDevice` and `EdgeDeviceSet`. The following PR will improve the `list` command for workloads and devices similarly.

Signed-off-by: arielireni <aireni@redhat.com>