### PR TITLE
Update `[--all|-a]` flag in `delete deviceset` command

### DIFF
--- a/internal/cmd/delete/deviceset.go
+++ b/internal/cmd/delete/deviceset.go
@@ -88,6 +88,11 @@ func init() {
 		fmt.Fprintf(os.Stderr, "Failed to set flag `name` as required: %v\n", err)
 		os.Exit(1)
 	}
+
+	// if "all" flag was provided, set "deleteDevices" flag to true
+	if deviceSetCmd.Flags().Lookup("all").Changed {
+		deleteDevices = true
+	}
 }
 
 func getDevicesNamesList() ([]string, error) {


### PR DESCRIPTION
Now `delete deviceset -n <device-set> [--all|-a]` will delete both the device-set and its devices (without providing `true` as the value of the flag).

Signed-off-by: arielireni <aireni@redhat.com>