### PR TITLE
Update devices of device-set default prefix

### DIFF
--- a/internal/cmd/add/deviceset.go
+++ b/internal/cmd/add/deviceset.go
@@ -31,6 +31,7 @@ func NewDeviceSetCmd() *cobra.Command {
 			// if devices prefix has not been specified, use deviceSetName as prefix
 			if deviceNamePrefix == "" {
 				deviceNamePrefix = deviceSetName
+				deviceNamePrefix = fmt.Sprintf("%s-device", deviceSetName)
 			}
 
 			client, err := resources.NewClient()


### PR DESCRIPTION
Following comments in #63, the devices prefix was updated to `<device-set>-device#`.
Now, after registering new devices as part of `add devicset` command (without mentioning the devices prefix), the result will be:

```
→ ./bin/flotta add deviceset -n set1 -s 2
device-set 'set1' was added
device 'set1-device1' was added successfully to device-set 'set1' (1/2)
device 'set1-device2' was added successfully to device-set 'set1' (2/2)

→ ./bin/flotta list device
NAME		STATUS		CREATED
set1-device1	running		7 minutes ago
set1-device2	running		7 minutes ago
```

Signed-off-by: arielireni <aireni@redhat.com>