### PR TITLE
Replace `list` output when there are no matching resources

### DIFF
--- a/internal/cmd/list/device.go
+++ b/internal/cmd/list/device.go
@@ -59,10 +59,15 @@ func NewDeviceCmd() *cobra.Command {
 			})
 
 			writer := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 8, 2, '\t', tabwriter.AlignRight)
-
 			defer writer.Flush()
 
-			fmt.Fprintf(writer, "%s\t%s\t%s\t\n", "NAME", "STATUS", "CREATED")
+			// if there are no devices, print a message and return
+			if len(containers) == 0 {
+				fmt.Fprintf(cmd.OutOrStdout(), "No resources were found.\n")
+				return nil
+			} else {
+				fmt.Fprintf(writer, "%s\t%s\t%s\t\n", "NAME", "STATUS", "CREATED")
+			}
 
 			for _, container := range containers {
 				containerName := container.Names[0][1:]

--- a/internal/cmd/list/deviceset.go
+++ b/internal/cmd/list/deviceset.go
@@ -34,11 +34,6 @@ func NewDeviceSetCmd() *cobra.Command {
 		Aliases: []string{"devicesets"},
 		Short:   "List device-sets",
 		RunE: func(cmd *cobra.Command, args []string) error {
-
-			writer := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 8, 2, '\t', tabwriter.AlignRight)
-			defer writer.Flush()
-			fmt.Fprintf(writer, "%s\t%s\t%s\t\n", "NAME", "DEVICES", "CREATED")
-
 			client, err := resources.NewClient()
 			if err != nil {
 				fmt.Fprintf(cmd.OutOrStderr(), "NewClient failed: %v\n", err)
@@ -55,6 +50,17 @@ func NewDeviceSetCmd() *cobra.Command {
 			if err != nil {
 				fmt.Fprintf(cmd.OutOrStderr(), "List() device-set failed: %v\n", err)
 				return err
+			}
+
+			writer := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 8, 2, '\t', tabwriter.AlignRight)
+			defer writer.Flush()
+
+			// if there are no device-sets, print a message and return
+			if len(setsList.Items) == 0 {
+				fmt.Fprintf(cmd.OutOrStderr(), "No resources were found.\n")
+				return nil
+			} else {
+				fmt.Fprintf(writer, "%s\t%s\t%s\t\n", "NAME", "DEVICES", "CREATED")
 			}
 
 			// create a list of all registered devices

--- a/internal/cmd/list/workload.go
+++ b/internal/cmd/list/workload.go
@@ -34,11 +34,6 @@ func NewWorkloadCmd() *cobra.Command {
 		Aliases: []string{"workloads"},
 		Short:   "List workloads",
 		RunE: func(cmd *cobra.Command, args []string) error {
-
-			writer := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 8, 2, '\t', tabwriter.AlignRight)
-			defer writer.Flush()
-			fmt.Fprintf(writer, "%s\t%s\t%s\t\n", "NAME", "STATUS", "CREATED")
-
 			client, err := resources.NewClient()
 			if err != nil {
 				fmt.Fprintf(cmd.OutOrStderr(), "NewClient failed: %v\n", err)
@@ -55,7 +50,11 @@ func NewWorkloadCmd() *cobra.Command {
 				fmt.Fprintf(cmd.OutOrStderr(), "List() device failed: %v\n", err)
 			}
 
+			writer := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 8, 2, '\t', tabwriter.AlignRight)
+			defer writer.Flush()
+
 			// loop over registered devices
+			foundWorkload := false
 			for _, dvc := range devicesList.Items {
 				device, err := resources.NewEdgeDevice(client, dvc.Name)
 				if err != nil {
@@ -71,6 +70,10 @@ func NewWorkloadCmd() *cobra.Command {
 				}
 				workloads := registeredDevice.Status.Workloads
 				for _, workload := range workloads {
+					if !foundWorkload {
+						foundWorkload = true
+						fmt.Fprintf(writer, "%s\t%s\t%s\t\n", "NAME", "STATUS", "CREATED")
+					}
 					createdTime, err := getWorkloadCreationTime(workload.Name)
 					if err != nil {
 						fmt.Fprintf(cmd.OutOrStderr(), "getWorkloadCreationTime failed: %v\n", err)
@@ -79,6 +82,11 @@ func NewWorkloadCmd() *cobra.Command {
 					formattedTime := units.HumanDuration(time.Now().UTC().Sub(createdTime)) + " ago"
 					fmt.Fprintf(writer, "%s\t%v\t%s\t\n", workload.Name, workload.Phase, formattedTime)
 				}
+			}
+
+			// if there are no workloads, print a message
+			if !foundWorkload {
+				fmt.Fprintf(cmd.OutOrStderr(), "No resources were found.\n")
 			}
 			return nil
 		},


### PR DESCRIPTION
Currently, when there are no matching resources, the output of the list command is an empty table, for example:

```
→ ./bin/flotta list deviceset
NAME    DEVICES         CREATED
```

Now, we'll print an appropriate message instead:
```
→ ./bin/flotta list deviceset
No device sets were found.
```

Signed-off-by: arielireni <aireni@redhat.com>