### PR TITLE
Add `NoArgs` validation to all of the commands

### DIFF
--- a/internal/cmd/add/device.go
+++ b/internal/cmd/add/device.go
@@ -32,6 +32,7 @@ func NewDeviceCmd() *cobra.Command {
 		Use:     "device",
 		Aliases: []string{"devices"},
 		Short:   "Add a new device",
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := resources.NewClient()
 			if err != nil {

--- a/internal/cmd/add/deviceset.go
+++ b/internal/cmd/add/deviceset.go
@@ -21,6 +21,7 @@ func NewDeviceSetCmd() *cobra.Command {
 		Use:     "deviceset",
 		Aliases: []string{"devicesets"},
 		Short:   "Add a new device set with registered devices",
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if deviceSetSize < 0 {
 				err := fmt.Errorf("deviceSetSize is invalid: %d. Only positive values are allowed", deviceSetSize)

--- a/internal/cmd/add/workload.go
+++ b/internal/cmd/add/workload.go
@@ -45,6 +45,7 @@ func NewWorkloadCmd() *cobra.Command {
 		Use:     "workload",
 		Aliases: []string{"workloads"},
 		Short:   "Add a new workload",
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if workloadImage == "" {
 				workloadImage = defaultImage

--- a/internal/cmd/delete/device.go
+++ b/internal/cmd/delete/device.go
@@ -33,6 +33,7 @@ func NewDeviceCmd() *cobra.Command {
 		Use:     "device",
 		Aliases: []string{"devices"},
 		Short:   "Delete a device from flotta",
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := resources.NewClient()
 			if err != nil {

--- a/internal/cmd/delete/deviceset.go
+++ b/internal/cmd/delete/deviceset.go
@@ -39,6 +39,7 @@ func NewDeviceSetCommand() *cobra.Command {
 		Use:     "deviceset",
 		Aliases: []string{"devicesets"},
 		Short:   "Delete a deviceset from flotta",
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := resources.NewClient()
 			if err != nil {

--- a/internal/cmd/delete/workload.go
+++ b/internal/cmd/delete/workload.go
@@ -32,6 +32,7 @@ func NewWorkloadCmd() *cobra.Command {
 		Use:     "workload",
 		Aliases: []string{"workloads"},
 		Short:   "Delete a workload from flotta",
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := resources.NewClient()
 			if err != nil {

--- a/internal/cmd/list/device.go
+++ b/internal/cmd/list/device.go
@@ -35,6 +35,7 @@ func NewDeviceCmd() *cobra.Command {
 		Use:     "device",
 		Aliases: []string{"devices"},
 		Short:   "List devices",
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 			cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())

--- a/internal/cmd/list/deviceset.go
+++ b/internal/cmd/list/deviceset.go
@@ -33,6 +33,7 @@ func NewDeviceSetCmd() *cobra.Command {
 		Use:     "deviceset",
 		Aliases: []string{"devicesets"},
 		Short:   "List device-sets",
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			writer := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 8, 2, '\t', tabwriter.AlignRight)

--- a/internal/cmd/list/workload.go
+++ b/internal/cmd/list/workload.go
@@ -33,6 +33,7 @@ func NewWorkloadCmd() *cobra.Command {
 		Use:     "workload",
 		Aliases: []string{"workloads"},
 		Short:   "List workloads",
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			writer := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 8, 2, '\t', tabwriter.AlignRight)

--- a/internal/cmd/start/device.go
+++ b/internal/cmd/start/device.go
@@ -32,6 +32,7 @@ func NewDeviceCmd() *cobra.Command {
 		Use:     "device",
 		Aliases: []string{"devices"},
 		Short:   "Start a device",
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := resources.NewClient()
 			if err != nil {

--- a/internal/cmd/stop/device.go
+++ b/internal/cmd/stop/device.go
@@ -32,6 +32,7 @@ func NewDeviceCmd() *cobra.Command {
 		Use:     "device",
 		Aliases: []string{"devices"},
 		Short:   "Stop a device",
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := resources.NewClient()
 			if err != nil {


### PR DESCRIPTION
All the commands receive their arguments by passing flags and their values. Therefore, we would like to verify that passing arguments in any other way is not allowed, to avoid unwanted behavior. For example, in the `add workload` command we received unwanted behavior as described in #77.

This PR includes adding: `Args: cobra.NoArgs` to all of the commands, which will verify the above.

Signed-off-by: arielireni <aireni@redhat.com>