### PR TITLE
Add `get-certs` to `add device` command

### DIFF
--- a/internal/cmd/start/start_test.go
+++ b/internal/cmd/start/start_test.go
@@ -21,7 +21,7 @@ var _ = Describe("Start", func() {
 		actualOut *bytes.Buffer
 		actualErr *bytes.Buffer
 		rootCmd   *cobra.Command
-		startCmd   *cobra.Command
+		startCmd  *cobra.Command
 	)
 
 	BeforeEach(func() {


### PR DESCRIPTION
Instead of running `make get-certs` from the operator side before adding a new device, now the commands from the `get-certs` target will run as part of the `add device` command.

Signed-off-by: arielireni <aireni@redhat.com>