### PR TITLE
Fix duplication in error message

### DIFF
--- a/internal/cmd/add/device.go
+++ b/internal/cmd/add/device.go
@@ -36,24 +36,20 @@ func NewDeviceCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := resources.NewClient()
 			if err != nil {
-				fmt.Fprintf(cmd.OutOrStderr(), "NewClient failed: %v\n", err)
 				return err
 			}
 
 			device, err := resources.NewEdgeDevice(client, deviceName)
 			if err != nil {
-				fmt.Fprintf(cmd.OutOrStderr(), "NewEdgeDevice failed: %v\n", err)
 				return err
 			}
 
 			dvc, err := device.Get()
 			if err == nil && dvc != nil {
-				fmt.Fprintf(cmd.OutOrStderr(), "failed: device '%s' already exists\n", deviceName)
 				return fmt.Errorf("edgedevices.management.project-flotta.io \"%s\" already exists", deviceName)
 			} else {
 				errSubstring := fmt.Sprintf("edgedevices.management.project-flotta.io \"%s\" not found", deviceName)
 				if !strings.Contains(err.Error(), errSubstring) {
-					fmt.Fprintf(cmd.OutOrStderr(), "failed: %v\n", err)
 					return err
 				}
 			}
@@ -63,11 +59,9 @@ func NewDeviceCmd() *cobra.Command {
 				// if device.Register() failed, remove the container
 				err2 := device.Remove()
 				if err2 != nil {
-					fmt.Fprintf(cmd.OutOrStderr(), "Remove device that failed to register failed: %v\n", err2)
-					return err
+					return err2
 				}
 
-				fmt.Fprintf(cmd.OutOrStderr(), "Register device failed: %v\n", err)
 				return err
 			}
 

--- a/internal/cmd/add/deviceset.go
+++ b/internal/cmd/add/deviceset.go
@@ -25,7 +25,6 @@ func NewDeviceSetCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if deviceSetSize < 0 {
 				err := fmt.Errorf("deviceSetSize is invalid: %d. Only positive values are allowed", deviceSetSize)
-				fmt.Fprintf(cmd.OutOrStderr(), err.Error()+"\n")
 				return err
 			}
 
@@ -37,19 +36,16 @@ func NewDeviceSetCmd() *cobra.Command {
 
 			client, err := resources.NewClient()
 			if err != nil {
-				fmt.Fprintf(cmd.OutOrStderr(), "NewClient failed %v\n", err)
 				return err
 			}
 
 			deviceset, err := resources.NewEdgeDeviceSet(client, deviceSetName)
 			if err != nil {
-				fmt.Fprintf(cmd.OutOrStderr(), "NewEdgeDeviceSet failed: %v\n", err)
 				return err
 			}
 
 			_, err = deviceset.Create(resources.EdgeDeviceSetConfig(deviceSetName))
 			if err != nil {
-				fmt.Fprintf(cmd.OutOrStderr(), "Create device-set failed: %v\n", err)
 				return err
 			}
 

--- a/internal/cmd/add/workload.go
+++ b/internal/cmd/add/workload.go
@@ -55,7 +55,6 @@ func NewWorkloadCmd() *cobra.Command {
 			splitImage := strings.Split(workloadImage, "/")
 			normalizedImage, error := NormalizeString(splitImage[len(splitImage)-1])
 			if error != nil {
-				fmt.Fprintf(cmd.OutOrStderr(), "image: %s contains invalid characters\n", workloadImage)
 				return error
 			}
 
@@ -65,36 +64,30 @@ func NewWorkloadCmd() *cobra.Command {
 
 			client, err := resources.NewClient()
 			if err != nil {
-				fmt.Fprintf(cmd.OutOrStderr(), "NewClient failed: %v\n", err)
 				return err
 			}
 
 			device, err := resources.NewEdgeDevice(client, deviceID)
 			if err != nil {
-				fmt.Fprintf(cmd.OutOrStderr(), "NewEdgeDevice failed: %v\n", err)
 				return err
 			}
 
 			_, err = device.Get()
 			if err != nil {
-				fmt.Fprintf(cmd.OutOrStderr(), "Get device '%s' failed: %v\n", deviceID, err)
 				return err
 			}
 			workload, err := resources.NewEdgeWorkload(client)
 			if err != nil {
-				fmt.Fprintf(cmd.OutOrStderr(), "NewEdgeWorkload failed: %v\n", err)
 				return err
 			}
 
 			_, err = workload.Create(resources.EdgeworkloadDeviceId(workloadName, deviceID, workloadImage))
 			if err != nil {
-				fmt.Fprintf(cmd.OutOrStderr(), "Create workload '%s' failed: %v\n", workloadName, err)
 				return err
 			}
 
 			err = device.WaitForWorkloadState(workloadName, "Running")
 			if err != nil {
-				fmt.Fprintf(cmd.OutOrStderr(), "WaitForWorkloadState failed: %v\n", err)
 				return err
 			}
 

--- a/internal/cmd/delete/device.go
+++ b/internal/cmd/delete/device.go
@@ -37,25 +37,21 @@ func NewDeviceCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := resources.NewClient()
 			if err != nil {
-				fmt.Fprintf(cmd.OutOrStderr(), "NewClient failed: %v\n", err)
 				return err
 			}
 
 			device, err := resources.NewEdgeDevice(client, deviceName)
 			if err != nil {
-				fmt.Fprintf(cmd.OutOrStderr(), "NewEdgeDevice failed: %v\n", err)
 				return err
 			}
 
 			err = device.Unregister()
 			if err != nil {
-				fmt.Fprintf(cmd.OutOrStderr(), "Unregister failed: %v\n", err)
 				return err
 			}
 
 			err = device.Remove()
 			if err != nil {
-				fmt.Fprintf(cmd.OutOrStderr(), "Remove failed: %v\n", err)
 				return err
 			}
 

--- a/internal/cmd/delete/deviceset.go
+++ b/internal/cmd/delete/deviceset.go
@@ -43,19 +43,16 @@ func NewDeviceSetCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := resources.NewClient()
 			if err != nil {
-				fmt.Fprintf(cmd.OutOrStderr(), "NewClient failed: %v\n", err)
 				return err
 			}
 
 			deviceset, err := resources.NewEdgeDeviceSet(client, deviceSetName)
 			if err != nil {
-				fmt.Fprintf(cmd.OutOrStderr(), "NewEdgeDeviceSet failed: %v\n", err)
 				return err
 			}
 
 			err = deviceset.Remove(deviceSetName)
 			if err != nil {
-				fmt.Fprintf(cmd.OutOrStderr(), "Remove deviceset failed: %v\n", err)
 				return err
 			}
 
@@ -63,7 +60,6 @@ func NewDeviceSetCmd() *cobra.Command {
 
 			devices, err := getDevicesNamesList()
 			if err != nil {
-				fmt.Fprintf(cmd.OutOrStderr(), "getDevicesList failed: %v\n", err)
 				return err
 			}
 

--- a/internal/cmd/delete/workload.go
+++ b/internal/cmd/delete/workload.go
@@ -36,19 +36,16 @@ func NewWorkloadCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := resources.NewClient()
 			if err != nil {
-				fmt.Fprintf(cmd.OutOrStderr(), "NewClient failed: %v\n", err)
 				return err
 			}
 
 			workload, err := resources.NewEdgeWorkload(client)
 			if err != nil {
-				fmt.Fprintf(cmd.OutOrStderr(), "NewEdgeWorkload failed: %v\n", err)
 				return err
 			}
 
 			err = workload.Remove(workloadName)
 			if err != nil {
-				fmt.Fprintf(cmd.OutOrStderr(), "Remove workload failed: %v\n", err)
 				return err
 			}
 

--- a/internal/cmd/list/device.go
+++ b/internal/cmd/list/device.go
@@ -40,7 +40,6 @@ func NewDeviceCmd() *cobra.Command {
 			ctx := context.Background()
 			cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 			if err != nil {
-				fmt.Fprintf(cmd.OutOrStderr(), "NewClientWithOpts failed: %v\n", err)
 				return err
 			}
 
@@ -50,7 +49,6 @@ func NewDeviceCmd() *cobra.Command {
 
 			containers, err := cli.ContainerList(ctx, opts)
 			if err != nil {
-				fmt.Fprintf(cmd.OutOrStderr(), "ContainerList failed: %v\n", err)
 				return err
 			}
 

--- a/internal/cmd/list/deviceset.go
+++ b/internal/cmd/list/deviceset.go
@@ -37,19 +37,16 @@ func NewDeviceSetCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := resources.NewClient()
 			if err != nil {
-				fmt.Fprintf(cmd.OutOrStderr(), "NewClient failed: %v\n", err)
 				return err
 			}
 
 			// create a list of all device-sets
 			deviceset, err := resources.NewEdgeDeviceSet(client, "")
 			if err != nil {
-				fmt.Fprintf(cmd.OutOrStderr(), "NewEdgeDeviceSet failed: %v\n", err)
 				return err
 			}
 			setsList, err := deviceset.List()
 			if err != nil {
-				fmt.Fprintf(cmd.OutOrStderr(), "List() device-set failed: %v\n", err)
 				return err
 			}
 
@@ -67,12 +64,10 @@ func NewDeviceSetCmd() *cobra.Command {
 			// create a list of all registered devices
 			device, err := resources.NewEdgeDevice(client, "")
 			if err != nil {
-				fmt.Fprintf(cmd.OutOrStderr(), "NewEdgeDeviceSet failed: %v\n", err)
 				return err
 			}
 			devicesList, err := device.List()
 			if err != nil {
-				fmt.Fprintf(cmd.OutOrStderr(), "List() device failed: %v\n", err)
 				return err
 			}
 

--- a/internal/cmd/list/workload.go
+++ b/internal/cmd/list/workload.go
@@ -37,18 +37,17 @@ func NewWorkloadCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := resources.NewClient()
 			if err != nil {
-				fmt.Fprintf(cmd.OutOrStderr(), "NewClient failed: %v\n", err)
 				return err
 			}
 
 			// create a list of all registered devices
 			device, err := resources.NewEdgeDevice(client, "")
 			if err != nil {
-				fmt.Fprintf(cmd.OutOrStderr(), "NewEdgeDeviceSet failed: %v\n", err)
+				return err
 			}
 			devicesList, err := device.List()
 			if err != nil {
-				fmt.Fprintf(cmd.OutOrStderr(), "List() device failed: %v\n", err)
+				return err
 			}
 
 			writer := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 8, 2, '\t', tabwriter.AlignRight)
@@ -59,14 +58,12 @@ func NewWorkloadCmd() *cobra.Command {
 			for _, dvc := range devicesList.Items {
 				device, err := resources.NewEdgeDevice(client, dvc.Name)
 				if err != nil {
-					fmt.Fprintf(cmd.OutOrStderr(), "NewEdgeDevice failed: %v\n", err)
 					return err
 				}
 
 				// get workloads by device
 				registeredDevice, err := device.Get()
 				if err != nil {
-					fmt.Fprintf(cmd.OutOrStderr(), "Get device failed: %v\n", err)
 					return err
 				}
 				workloads := registeredDevice.Status.Workloads
@@ -77,7 +74,6 @@ func NewWorkloadCmd() *cobra.Command {
 					}
 					createdTime, err := getWorkloadCreationTime(workload.Name)
 					if err != nil {
-						fmt.Fprintf(cmd.OutOrStderr(), "getWorkloadCreationTime failed: %v\n", err)
 						return err
 					}
 					formattedTime := units.HumanDuration(time.Now().UTC().Sub(createdTime)) + " ago"

--- a/internal/cmd/start/device.go
+++ b/internal/cmd/start/device.go
@@ -36,19 +36,16 @@ func NewDeviceCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := resources.NewClient()
 			if err != nil {
-				fmt.Fprintf(cmd.OutOrStderr(), "NewClient failed: %v\n", err)
 				return err
 			}
 
 			device, err := resources.NewEdgeDevice(client, deviceName)
 			if err != nil {
-				fmt.Fprintf(cmd.OutOrStderr(), "NewEdgeDevice failed: %v\n", err)
 				return err
 			}
 
 			err = device.Start()
 			if err != nil {
-				fmt.Fprintf(cmd.OutOrStderr(), "Start failed: %v\n", err)
 				return err
 			}
 

--- a/internal/cmd/start/start_test.go
+++ b/internal/cmd/start/start_test.go
@@ -21,7 +21,7 @@ var _ = Describe("Start", func() {
 		actualOut *bytes.Buffer
 		actualErr *bytes.Buffer
 		rootCmd   *cobra.Command
-		startCmd   *cobra.Command
+		startCmd  *cobra.Command
 	)
 
 	BeforeEach(func() {

--- a/internal/cmd/stop/device.go
+++ b/internal/cmd/stop/device.go
@@ -36,19 +36,16 @@ func NewDeviceCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := resources.NewClient()
 			if err != nil {
-				fmt.Fprintf(cmd.OutOrStderr(), "NewClient failed: %v\n", err)
 				return err
 			}
 
 			device, err := resources.NewEdgeDevice(client, deviceName)
 			if err != nil {
-				fmt.Fprintf(cmd.OutOrStderr(), "NewEdgeDevice failed: %v\n", err)
 				return err
 			}
 
 			err = device.Stop()
 			if err != nil {
-				fmt.Fprintf(cmd.OutOrStderr(), "Stop failed: %v\n", err)
 				return err
 			}
 


### PR DESCRIPTION
After changing the commands' function to return an error (use `RunE` instead of `Run`), when an error occurred, the error message was printed twice, for example:
```
→ ./bin/flotta delete device -n device1
Unregister failed: edgedevices.management.project-flotta.io "device1" not found
Error: edgedevices.management.project-flotta.io "device1" not found
```

Signed-off-by: arielireni <aireni@redhat.com>