### PR TITLE
Fix: list workloads

### DIFF
--- a/internal/resources/edgeworkload.go
+++ b/internal/resources/edgeworkload.go
@@ -17,6 +17,7 @@ type EdgeWorkload interface {
 	Get(string) (*v1alpha1.EdgeWorkload, error)
 	Remove(string) error
 	RemoveAll() error
+	List() (*v1alpha1.EdgeWorkloadList, error)
 }
 
 type edgeWorkload struct {
@@ -51,6 +52,10 @@ func (e *edgeWorkload) Remove(name string) error {
 		}
 		return false
 	})
+}
+
+func (e *edgeWorkload) List() (*v1alpha1.EdgeWorkloadList, error) {
+	return e.workload.EdgeWorkloads(Namespace).List(context.TODO(), metav1.ListOptions{})
 }
 
 func (e *edgeWorkload) waitForWorkload(cond func() bool) error {


### PR DESCRIPTION
This PR fixes #58

Now we will print after the workloads list also the names of the workloads that their device was not found.
The output of the `list workload` command will become:
```
→ ./bin/flotta list workload
NAME			STATUS		CREATED		
nginx1-21-6-atxbniby	Running		8 minutes ago	
nginx1-21-6-lfsqhtyl	Running		10 minutes ago	

failed to get device status for workloads: edgeworkload-1, edgeworkload-2
```


Signed-off-by: arielireni <aireni@redhat.com>