### PR TITLE
Bug fix: change `certsMap` to a local variable

### DIFF
--- a/internal/resources/edgedevice.go
+++ b/internal/resources/edgedevice.go
@@ -32,7 +32,6 @@ var (
 	clientCertPath = filepath.Join(certsPath, "cert.pem")
 	clientKeyPath  = filepath.Join(certsPath, "key.pem")
 	certificates   = []string{CACertsPath, clientKeyPath, clientCertPath}
-	certsMap       = make(map[string][]byte)
 )
 
 const (
@@ -186,7 +185,8 @@ func (e *edgeDevice) CopyCerts() error {
 	}
 	defer os.RemoveAll(dir) // clean up
 
-	err = CopyCertsToTempDir(dir)
+	certsMap := make(map[string][]byte)
+	err = CopyCertsToTempDir(dir, certsMap)
 	if err != nil {
 		return err
 	}
@@ -221,7 +221,7 @@ func (e *edgeDevice) CopyCerts() error {
 	return nil
 }
 
-func CopyCertsToTempDir(dir string) error {
+func CopyCertsToTempDir(dir string, certsMap map[string][]byte) error {
 	// get secrets
 	config, err := GetKubeConfig()
 	if err != nil {


### PR DESCRIPTION
This PR fixes the following bug in the `add deviceset` command:
```
→ ./bin/flotta add deviceset -n set1 -s 2
device-set 'set1' was added
device 'set1-device1' was added successfully to device-set 'set1' (1/2)
NewDeviceToSet failed: cannot copy certificates to device: open /tmp/certs378247597/ca.pem: no such file or directory. Device: set1-device2
```
The error occurred since the path of the certs directory of the first device is still in `certsMap` (since it was a global variable), but the path does not exist in the container of the second device.

Signed-off-by: arielireni <aireni@redhat.com>
